### PR TITLE
Fix template string issues in vite setup

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -13,7 +13,7 @@ export function log(message: string, source = "express") {
     second: "2-digit",
     hour12: true,
   });
-  console.log(${formattedTime} [${source}] ${message});
+  console.log(`${formattedTime} [${source}] ${message}`);
 }
 export async function setupVite(app: Express, server: Server) {
  const serverOptions = {
@@ -49,8 +49,8 @@ export async function setupVite(app: Express, server: Server) {
       // always reload the index.html file from disk incase it changes
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
       template = template.replace(
-        src="/src/main.tsx",
-        src="/src/main.tsx?v=${nanoid()}",
+        'src="/src/main.tsx"',
+        `src="/src/main.tsx?v=${nanoid()}"`,
       );
       const page = await vite.transformIndexHtml(url, template);
       res.status(200).set({ "Content-Type": "text/html" }).end(page);
@@ -64,7 +64,7 @@ export function serveStatic(app: Express) {
   const distPath = path.resolve(import.meta.dirname, "public");
   if (!fs.existsSync(distPath)) {
     throw new Error(
-      Could not find the build directory: ${distPath}, make sure to build the client first,
+      `Could not find the build directory: ${distPath}, make sure to build the client first`,
     );
   }
   app.use(express.static(distPath));


### PR DESCRIPTION
## Summary
- fix template strings in `server/vite.ts`

## Testing
- `npm install`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_684ffe5698f88333a6b1a05cf337e004